### PR TITLE
Fix windows taskkill bug and build issue on clean checkout

### DIFF
--- a/build-res/subfloor-pkg.xml
+++ b/build-res/subfloor-pkg.xml
@@ -91,6 +91,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   <target name="assemble.init">
     <mkdir dir="${approot.stage.dir}" />
+    <mkdir dir="${package.resdir}" />
   </target>
 
   <target name="assemble" depends="assemble.init,assemble.copy-libs">

--- a/src/org/pentaho/python/PythonSession.java
+++ b/src/org/pentaho/python/PythonSession.java
@@ -567,7 +567,7 @@ public class PythonSession {
           // try to kill process, just in case
           ProcessBuilder killer;
           if ( System.getProperty( "os.name" ).toLowerCase().contains( "win" ) ) {
-            killer = new ProcessBuilder( "takskill", "/F", "/PID", "" + m_pythonPID );
+            killer = new ProcessBuilder( "taskkill", "/F", "/PID", "" + m_pythonPID );
           } else {
             killer = new ProcessBuilder( "kill", "-9", "" + m_pythonPID );
           }


### PR DESCRIPTION
Hi Mark,

I forked this from you rather than pentaho-labs, sorry, but I figure you're likely the maintainer on this anyway?  Bit of a hiccup on Windows but this typo correction fixes it, build issue is simply creating a needed empty directory if it doesn't exist.  Thanks.